### PR TITLE
Fix Tailwind postcss plugin

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "react-scripts": "^5.0.1",
+    "@tailwindcss/postcss": "^0.1.0",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3"
   }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
-} 
+}


### PR DESCRIPTION
## Summary
- update postcss config to use `@tailwindcss/postcss`
- add `@tailwindcss/postcss` to dev dependencies

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python backend/test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*