### PR TITLE
Fix PostCSS config for Tailwind 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ This repository contains a wildfire visualization system built with React (front
    ```bash
    cd frontend
    npm install
+   # Tailwind CSS v4 requires the PostCSS plugin
+   # `@tailwindcss/postcss` to be installed.
+   # Ensure postcss.config.js uses:
+   #   plugins: [require('@tailwindcss/postcss'), require('autoprefixer')]
    npm start
    ```
 

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require("@tailwindcss/postcss"),
+    require("autoprefixer"),
+  ],
 }


### PR DESCRIPTION
## Summary
- update PostCSS configuration to use `@tailwindcss/postcss`
- document Tailwind 4 postcss plugin requirement in `AGENTS.md`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `python backend/test_api.py` *(fails: No module named 'requests')*