### PR TITLE
refactor: translate comments and polish UI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ A global wildfire data visualization system based on NASA FIRMS API, supporting 
 
 ## Features
 
-- 🌍 Global wildfire data visualization with interactive map
-- 🔍 Country or region-based query support
-- 📅 Time series data display with date slider
-- 🎯 Detailed wildfire point information
-- 📊 Multiple visualization layers:
+- Global wildfire data visualization with an interactive map
+- Country or region-based query support
+- Time series data display with a date slider
+- Detailed wildfire point information
+- Multiple visualization layers:
   - Heatmap (always visible)
   - Clusters (always visible)
   - Statistics Panel (toggleable)
   - Trend Chart (toggleable)
   - Radar Chart (toggleable)
-- 📱 Responsive design with modern UI
+- Responsive design with a modern interface
 
 ## Quick Start
 

--- a/backend/debug_response.py
+++ b/backend/debug_response.py
@@ -5,16 +5,16 @@ from datetime import datetime
 
 def debug_response():
     url = "http://localhost:8000/fires"
-    
-    # 使用与前端一致的参数
+
+    # Use parameters consistent with the frontend
     params = {
         "country": "USA",
         "start_date": "2025-05-20",
         "end_date": "2025-05-21"
     }
-    
+
     print(f"Testing with parameters: {params}")
-    
+
     try:
         response = requests.get(url, params=params)
         print("Status Code:", response.status_code)
@@ -26,26 +26,26 @@ def debug_response():
                 data = response.json()
                 print("\nResponse is valid JSON")
                 print("Response Data Length:", len(data))
-                
-                # 检查数据结构是否符合前端 FirePoint 接口
+
+                # Check whether the data structure matches the frontend FirePoint interface
                 if len(data) > 0:
                     first_item = data[0]
                     print("\nFirst item keys:", list(first_item.keys()))
-                    
+
                     required_keys = [
-                        "latitude", "longitude", "bright_ti4", "bright_ti5", 
-                        "frp", "confidence", "acq_date", "acq_time", 
-                        "satellite", "country_id", "daynight", "instrument", 
+                        "latitude", "longitude", "bright_ti4", "bright_ti5",
+                        "frp", "confidence", "acq_date", "acq_time",
+                        "satellite", "country_id", "daynight", "instrument",
                         "scan", "track", "version"
                     ]
-                    
+
                     missing_keys = [key for key in required_keys if key not in first_item]
                     if missing_keys:
                         print("\nWARNING: Missing required keys:", missing_keys)
                     else:
                         print("\nAll required keys present")
-                    
-                    # 检查 acq_date 格式
+
+                    # Check the acq_date format
                     if "acq_date" in first_item:
                         print("\nacq_date format:", first_item["acq_date"])
                         try:
@@ -53,8 +53,8 @@ def debug_response():
                             print("acq_date format is valid")
                         except ValueError:
                             print("WARNING: acq_date format is invalid!")
-                    
-                    # 输出完整的第一条记录
+
+                    # Output the complete first record
                     print("\nFirst record details:")
                     pprint(first_item)
                 else:
@@ -66,9 +66,9 @@ def debug_response():
         else:
             print("\nError Response:")
             print(response.text)
-        
+
     except requests.exceptions.RequestException as e:
         print("Error:", str(e))
 
 if __name__ == "__main__":
-    debug_response() 
+    debug_response()

--- a/backend/main.py
+++ b/backend/main.py
@@ -112,7 +112,7 @@ def _fetch_firms_data(url: str) -> List[Dict]:
             "If failing repeatedly, try reducing the time span or using coordinate query."
         )
 
-# ---------- 核心路由 ----------
+# ---------- Core Routes ----------
 @app.get("/")
 async def root():
     return {"message": "Welcome to Wildfire Visualization API"}
@@ -192,18 +192,18 @@ def get_fires(
         query_params = f"/{country.upper()}/{day_range}/{start.isoformat()}"
     else:  # bbox mode
         base = f"https://firms.modaps.eosdis.nasa.gov/api/area/{fmt}/{MAP_KEY}"
-        # 按照官方规范格式: .../{SOURCE}/{west,south,east,north}/{DAY_RANGE}/{START_DATE}
-        # 注意不需要先组装bbox，直接按顺序放入参数
-        query_params = ""  # 在bbox模式下，直接在URL中添加数据源和参数
+        # According to official format: .../{SOURCE}/{west,south,east,north}/{DAY_RANGE}/{START_DATE}
+        # No need to assemble the bbox; parameters are placed in order
+        query_params = ""  # In bbox mode, add data source and parameters directly in the URL
 
     # 4) Try NRT data first
     if mode == "country":
         nrt_url = f"{base}/VIIRS_SNPP_NRT{query_params}"
     else:  # bbox mode
-        # 对于bbox模式，按照官方规范直接构建完整URL
+        # For bbox mode, construct the full URL directly per official spec
         nrt_url = f"{base}/VIIRS_SNPP_NRT/{west},{south},{east},{north}/{day_range}/{start.isoformat()}"
         
-    print(f"DEBUG - NRT URL: {nrt_url}")  # 调试打印URL
+    print(f"DEBUG - NRT URL: {nrt_url}")  # Debug print URL
     nrt_data = _fetch_firms_data(nrt_url)
     
     # If NRT has data, return directly
@@ -214,10 +214,10 @@ def get_fires(
     if mode == "country":
         sp_url = f"{base}/VIIRS_SNPP_SP{query_params}"
     else:  # bbox mode
-        # 对于bbox模式，按照官方规范直接构建完整URL
+        # For bbox mode, construct the full URL directly per official spec
         sp_url = f"{base}/VIIRS_SNPP_SP/{west},{south},{east},{north}/{day_range}/{start.isoformat()}"
         
-    print(f"DEBUG - SP URL: {sp_url}")  # 调试打印URL
+    print(f"DEBUG - SP URL: {sp_url}")  # Debug print URL
     sp_data = _fetch_firms_data(sp_url)
     
     # If no SP data either, return empty array
@@ -240,7 +240,7 @@ async def cors_test():
 async def debug_bbox_endpoint():
     """Debug endpoint to check BBOX API calls"""
     try:
-        # 使用示例边界坐标进行测试
+        # Use sample boundary coordinates for testing
         west = -100.0
         south = 30.0
         east = -80.0
@@ -248,22 +248,22 @@ async def debug_bbox_endpoint():
         day_range = 1
         start_date = "2023-07-01"
         
-        # 构建API URL - 使用area而不是bbox作为端点
+        # Build API URL - use 'area' instead of 'bbox' endpoint
         base_url = f"https://firms.modaps.eosdis.nasa.gov/api/area/csv/{MAP_KEY}"
         
-        # 按照官方规范构建URL
+        # Construct the URL according to official specs
         # .../{SOURCE}/{west,south,east,north}/{DAY_RANGE}/{START_DATE}
         nrt_url = f"{base_url}/VIIRS_SNPP_NRT/{west},{south},{east},{north}/{day_range}/{start_date}"
         sp_url = f"{base_url}/VIIRS_SNPP_SP/{west},{south},{east},{north}/{day_range}/{start_date}"
         
-        # 尝试调用API
+        # Try calling the API
         session = requests.Session()
         session.mount("https://", requests.adapters.HTTPAdapter(max_retries=3))
         
-        # 仅测试一个API调用的响应
+        # Test the response of a single API call
         resp = session.get(nrt_url, timeout=(30, 120))
         
-        # 返回调试信息
+        # Return debug information
         return {
             "nrt_url": nrt_url,
             "sp_url": sp_url,

--- a/backend/test_current.py
+++ b/backend/test_current.py
@@ -4,28 +4,28 @@ from datetime import datetime, timedelta
 
 def test_current_fires():
     url = "http://localhost:8000/fires"
-    
-    # 使用当前日期
+
+    # Use the current date
     today = datetime.now().date()
     yesterday = today - timedelta(days=1)
-    
-    # 格式化日期为 YYYY-MM-DD
+
+    # Format dates as YYYY-MM-DD
     end_date = today.strftime("%Y-%m-%d")
     start_date = yesterday.strftime("%Y-%m-%d")
-    
+
     params = {
         "country": "USA",
         "start_date": start_date,
         "end_date": end_date
     }
-    
+
     print(f"Testing with parameters: {params}")
-    
+
     try:
         response = requests.get(url, params=params)
         print("Status Code:", response.status_code)
         print("Headers:", dict(response.headers))
-        
+
         if response.status_code == 200:
             data = response.json()
             print("\nResponse Data Length:", len(data))
@@ -39,9 +39,9 @@ def test_current_fires():
         else:
             print("\nError Response:")
             print(response.text)
-        
+
     except requests.exceptions.RequestException as e:
         print("Error:", str(e))
 
 if __name__ == "__main__":
-    test_current_fires() 
+    test_current_fires()

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,8 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f3f4f6;
+}
+
 .App {
   text-align: center;
   height: 100vh;
@@ -17,9 +22,10 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background: linear-gradient(135deg, #1e3a8a, #2563eb);
   padding: 1rem;
   color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .App-header h1 {
@@ -32,16 +38,18 @@ main {
   padding: 1rem;
   display: flex;
   flex-direction: column;
-  background-color: #f5f5f5;
+  background-color: #f9fafb;
 }
 
-/* 确保地图容器能够正确显示 */
+/* Ensure the map container displays correctly */
 .leaflet-container {
   width: 100%;
   height: 100%;
   min-height: 500px;
   border-radius: 8px;
+  border: 1px solid #e5e7eb;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
 }
 
 .App-link {
@@ -64,6 +72,7 @@ main {
   border-radius: 4px;
   margin-bottom: 1rem;
   text-align: left;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .loading-message {
@@ -73,4 +82,5 @@ main {
   border-radius: 4px;
   margin-bottom: 1rem;
   text-align: left;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ const App: React.FC = () => {
   const handleSearch = async (params: SearchParams) => {
     setLoading(true);
     setError(null);
-    setFirePoints([]); // 清除之前的点
+    setFirePoints([]); // Clear previous points
 
     try {
       const queryParams = new URLSearchParams();

--- a/frontend/src/components/TimeSlider.tsx
+++ b/frontend/src/components/TimeSlider.tsx
@@ -11,7 +11,7 @@ interface TimeSliderProps {
 const TimeSlider: React.FC<TimeSliderProps> = ({ dates, currentDate, onTimeChange }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  // 当日期列表或当前日期变化时，更新滑块位置
+  // Update slider position when the date list or current date changes
   useEffect(() => {
     if (dates.length > 0) {
       const index = dates.indexOf(currentDate);
@@ -93,4 +93,4 @@ const TimeSlider: React.FC<TimeSliderProps> = ({ dates, currentDate, onTimeChang
   );
 };
 
-export default TimeSlider; 
+export default TimeSlider;


### PR DESCRIPTION
## Summary
- replace remaining Chinese comments with English in backend utilities and frontend components
- refine layout styling for a more polished interface
- professionalize documentation by removing emojis and clarifying feature list

## Testing
- `pytest`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68950f2ebe4883328cf3430394e01400