### PR TITLE
feat: switch to FIRMS v4 with MAP key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ pip install -r requirements.txt
 ```
 
 4. Configure environment variables:
-Create `.env` file and add your FIRMS API key:
+Create `.env` file and add your FIRMS MAP key:
 ```
-FIRMS_API_KEY=your_api_key_here
+FIRMS_MAP_KEY=your_map_key_here
 ```
+If `FIRMS_MAP_KEY` is not set, the application will fallback to the deprecated `FIRMS_API_KEY` and print a warning.
 
 5. Start server:
 ```bash
 uvicorn main:app --reload
 ```
+
+The backend now uses NASA FIRMS API v4 endpoints and supports a `source` query parameter (default `VIIRS_SNPP_NRT`).
 
 ### Start Frontend
 1. Navigate to frontend directory:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,18 @@
+# API 使用说明
+
+## 环境变量
+- `FIRMS_MAP_KEY`：NASA FIRMS MAP_KEY。
+- 兼容读取旧的 `FIRMS_API_KEY`（将打印弃用警告）。
+
+## /fires
+查询火点数据。
+
+### 查询参数
+- `country`：国家 ISO3 代码，或使用 `west` `south` `east` `north` 指定区域。
+- `start_date`、`end_date`：日期范围，最大 10 天。
+- `source`：数据源，默认 `VIIRS_SNPP_NRT`。
+  可选：`VIIRS_NOAA21_NRT`、`VIIRS_NOAA20_NRT`、`VIIRS_SNPP_NRT`、`VIIRS_NOAA20_SP`、`VIIRS_SNPP_SP`、`MODIS_NRT`、`MODIS_SP`、`LANDSAT_NRT`。
+
+后端使用 NASA FIRMS v4 CSV 端点：
+- Country：`/api/country/csv/{MAP_KEY}/{SOURCE}/{COUNTRY}/{DAY_RANGE}/{START_DATE}`
+- Area：`/api/area/csv/{MAP_KEY}/{SOURCE}/{west,south,east,north}/{DAY_RANGE}/{START_DATE}`


### PR DESCRIPTION
## Summary
- support FIRMS_MAP_KEY env var with FIRMS_API_KEY fallback
- migrate backend requests to FIRMS v4 and add `source` parameter
- document MAP key usage and v4 CSV endpoints

## Testing
- `pytest`
- USA and China bbox integration queries via TestClient

------
https://chatgpt.com/codex/tasks/task_e_6895e08dcb848332858ef73fe4766aa7