### PR TITLE
feat: add FIRMS URL builder utilities

### DIFF
--- a/backend/test_urlbuilder.py
+++ b/backend/test_urlbuilder.py
@@ -1,0 +1,63 @@
+from datetime import date
+
+from utils.urlbuilder import build_country_url, build_area_url, compose_urls
+
+
+def test_build_country_url_with_and_without_date():
+    url = build_country_url("K", "MODIS_NRT", "USA", 5, date(2024, 1, 1))
+    assert (
+        url
+        == "https://firms.modaps.eosdis.nasa.gov/api/country/csv/"
+        "K/MODIS_NRT/USA/5/2024-01-01"
+    )
+
+    url = build_country_url("K", "MODIS_NRT", "USA", 5)
+    assert (
+        url
+        == "https://firms.modaps.eosdis.nasa.gov/api/country/csv/"
+        "K/MODIS_NRT/USA/5"
+    )
+
+
+def test_build_area_url_world_and_bbox():
+    url = build_area_url("K", "MODIS_NRT", "world", 1)
+    assert (
+        url
+        == "https://firms.modaps.eosdis.nasa.gov/api/area/csv/"
+        "K/MODIS_NRT/world/1"
+    )
+
+    url = build_area_url("K", "MODIS_NRT", (-10.0, -20.0, 30.5, 40.2), 3, date(2024, 2, 15))
+    assert (
+        url
+        == "https://firms.modaps.eosdis.nasa.gov/api/area/csv/"
+        "K/MODIS_NRT/-10.0,-20.0,30.5,40.2/3/2024-02-15"
+    )
+
+
+def test_compose_urls_cross_month_and_year():
+    urls = compose_urls(
+        map_key="K",
+        source="MODIS_NRT",
+        start=date(2023, 12, 25),
+        end=date(2024, 1, 8),
+        area=(-10.0, -20.0, 30.5, 40.2),
+    )
+    assert urls == [
+        "https://firms.modaps.eosdis.nasa.gov/api/area/csv/"
+        "K/MODIS_NRT/-10.0,-20.0,30.5,40.2/10/2023-12-25",
+        "https://firms.modaps.eosdis.nasa.gov/api/area/csv/"
+        "K/MODIS_NRT/-10.0,-20.0,30.5,40.2/5/2024-01-04",
+    ]
+
+    urls = compose_urls(
+        map_key="K",
+        source="MODIS_NRT",
+        start=date(2024, 1, 28),
+        end=date(2024, 2, 2),
+        country="USA",
+    )
+    assert urls == [
+        "https://firms.modaps.eosdis.nasa.gov/api/country/csv/"
+        "K/MODIS_NRT/USA/6/2024-01-28"
+    ]

--- a/backend/utils/urlbuilder.py
+++ b/backend/utils/urlbuilder.py
@@ -1,0 +1,111 @@
+"""URL 构建工具，用于生成 NASA FIRMS API v4 请求 URL。
+
+该模块提供了针对 Country 与 Area 查询的 URL 拼接函数，
+并支持根据日期区间拆分请求。所有函数均为纯函数，
+便于单元测试与后续复用。
+"""
+
+from datetime import date, timedelta
+from typing import List, Optional, Tuple, Union
+
+BASE_URL = "https://firms.modaps.eosdis.nasa.gov/api"
+
+
+def build_country_url(
+    map_key: str,
+    source: str,
+    country: str,
+    day_range: int,
+    start: Optional[date] = None,
+) -> str:
+    """构造 Country 查询的 URL。
+
+    Args:
+        map_key: FIRMS 提供的 MAP_KEY。
+        source: 数据源名称。
+        country: ISO‑3 国家代码。
+        day_range: 查询的天数范围（1-10）。
+        start: 起始日期，未提供则使用默认（今日）数据。
+
+    Returns:
+        拼接好的 URL 字符串。
+    """
+
+    path = f"/country/csv/{map_key}/{source}/{country}/{day_range}"
+    if start:
+        path += f"/{start.isoformat()}"
+    return BASE_URL + path
+
+
+def build_area_url(
+    map_key: str,
+    source: str,
+    area: Union[str, Tuple[float, float, float, float]],
+    day_range: int,
+    start: Optional[date] = None,
+) -> str:
+    """构造 Area 查询的 URL。
+
+    Args:
+        map_key: FIRMS 提供的 MAP_KEY。
+        source: 数据源名称。
+        area: 传入 "world" 或 `(west, south, east, north)` 元组。
+        day_range: 查询的天数范围（1-10）。
+        start: 起始日期，未提供则使用默认（今日）数据。
+
+    Returns:
+        拼接好的 URL 字符串。
+    """
+
+    if area == "world":
+        area_part = "world"
+    else:
+        w, s, e, n = area  # type: ignore[misc]
+        area_part = f"{w},{s},{e},{n}"
+
+    path = f"/area/csv/{map_key}/{source}/{area_part}/{day_range}"
+    if start:
+        path += f"/{start.isoformat()}"
+    return BASE_URL + path
+
+
+def compose_urls(
+    map_key: str,
+    source: str,
+    start: date,
+    end: date,
+    country: Optional[str] = None,
+    area: Union[Tuple[float, float, float, float], str, None] = None,
+) -> List[str]:
+    """根据日期区间生成一组请求 URL。
+
+    若时间跨度超过 10 天，会按 10 天为上限拆分为多段。
+
+    Args:
+        map_key: FIRMS MAP_KEY。
+        source: 数据源名称。
+        start: 起始日期（包含）。
+        end: 结束日期（包含）。
+        country: ISO‑3 国家代码，与 `area` 二选一。
+        area: "world" 或 `(west, south, east, north)`，与 `country` 二选一。
+
+    Returns:
+        覆盖整个日期区间的 URL 列表。
+    """
+
+    if (country is None) == (area is None):
+        raise ValueError("provide exactly one of country or area")
+
+    urls: List[str] = []
+    cur = start
+    while cur <= end:
+        segment_end = min(cur + timedelta(days=9), end)
+        day_range = (segment_end - cur).days + 1
+        if country:
+            url = build_country_url(map_key, source, country, day_range, cur)
+        else:
+            url = build_area_url(map_key, source, area, day_range, cur)  # type: ignore[arg-type]
+        urls.append(url)
+        cur = segment_end + timedelta(days=1)
+
+    return urls

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,3 +19,19 @@
 后端使用 NASA FIRMS v4 CSV 端点：
 - Country：`/api/country/csv/{MAP_KEY}/{SOURCE}/{COUNTRY}/{DAY_RANGE}/{START_DATE}`
 - Area：`/api/area/csv/{MAP_KEY}/{SOURCE}/{west,south,east,north}/{DAY_RANGE}/{START_DATE}`
+
+## URL 拼接规范与样例
+
+### Country
+`https://firms.modaps.eosdis.nasa.gov/api/country/csv/{MAP_KEY}/{SOURCE}/{COUNTRY}/{DAY_RANGE}[/{START_DATE}]`
+
+示例：
+`https://firms.modaps.eosdis.nasa.gov/api/country/csv/KEY/MODIS_NRT/USA/5/2024-01-01`
+
+### Area
+`https://firms.modaps.eosdis.nasa.gov/api/area/csv/{MAP_KEY}/{SOURCE}/{west,south,east,north|world}/{DAY_RANGE}[/{START_DATE}]`
+
+示例：
+`https://firms.modaps.eosdis.nasa.gov/api/area/csv/KEY/MODIS_NRT/world/3`
+
+上述 `{START_DATE}` 可选，未提供时默认为当前日期向前追溯 `{DAY_RANGE}` 天。


### PR DESCRIPTION
## Summary
- add pure functions to build FIRMS country/area URLs and compose request segments
- document URL composition rules and examples
- cover URL builders with tests including world and cross-date ranges

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895eacb1dbc8332a61c00b7c9fd8ed2