### PR TITLE
feat: support FIRMS dataset availability and source priority

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.109.2
 uvicorn[standard]==0.27.1
 python-dotenv==1.0.1
 requests==2.31.0
-pydantic==2.6.1 
+pydantic==2.6.1
+httpx==0.27.0

--- a/backend/test_availability.py
+++ b/backend/test_availability.py
@@ -1,0 +1,84 @@
+from fastapi.testclient import TestClient
+from main import app
+
+
+def test_fallback_to_sp(monkeypatch):
+    client = TestClient(app)
+
+    def fake_check(map_key, sensor):
+        return {
+            "VIIRS_SNPP_NRT": ("2024-01-01", "2024-01-10"),
+            "VIIRS_SNPP_SP": ("2023-01-01", "2024-12-31"),
+        }
+
+    result = [
+        {
+            "latitude": "0",
+            "longitude": "0",
+            "bright_ti4": "0",
+            "acq_date": "2024-02-01",
+            "acq_time": "0000",
+        }
+    ]
+
+    called = {}
+
+    def fake_fetch(url):
+        called["url"] = url
+        return result
+
+    monkeypatch.setattr("main.check_data_availability", fake_check)
+    monkeypatch.setattr("main._fetch_firms_data", fake_fetch)
+
+    resp = client.get(
+        "/fires",
+        params={
+            "west": 0,
+            "south": 0,
+            "east": 1,
+            "north": 1,
+            "start_date": "2024-02-01",
+            "end_date": "2024-02-02",
+            "sourcePriority": "VIIRS_SNPP_NRT,VIIRS_SNPP_SP",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert "VIIRS_SNPP_SP" in called["url"]
+    assert resp.json() == result
+
+
+def test_no_source_available(monkeypatch):
+    client = TestClient(app)
+
+    def fake_check(map_key, sensor):
+        return {
+            "VIIRS_SNPP_NRT": ("2024-01-01", "2024-01-10"),
+            "VIIRS_SNPP_SP": ("2023-01-01", "2023-12-31"),
+        }
+
+    def fake_fetch(url):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr("main.check_data_availability", fake_check)
+    monkeypatch.setattr("main._fetch_firms_data", fake_fetch)
+
+    resp = client.get(
+        "/fires",
+        params={
+            "west": 0,
+            "south": 0,
+            "east": 1,
+            "north": 1,
+            "start_date": "2024-02-01",
+            "end_date": "2024-02-02",
+            "sourcePriority": "VIIRS_SNPP_NRT,VIIRS_SNPP_SP",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+    assert (
+        resp.headers.get("X-Data-Availability")
+        == "No data available for requested date range"
+    )

--- a/backend/utils/data_availability.py
+++ b/backend/utils/data_availability.py
@@ -1,0 +1,30 @@
+import csv
+from typing import Dict, Tuple
+import requests
+
+
+def check_data_availability(map_key: str, sensor: str = "ALL") -> Dict[str, Tuple[str, str]]:
+    """Return available date ranges for given sensor(s).
+
+    Parameters
+    ----------
+    map_key: str
+        NASA FIRMS MAP_KEY.
+    sensor: str, default "ALL"
+        Sensor dataset identifier or "ALL" for all datasets.
+
+    Returns
+    -------
+    Dict[str, Tuple[str, str]]
+        Mapping of dataset id to (min_date, max_date).
+    """
+    url = f"https://firms.modaps.eosdis.nasa.gov/api/data_availability/csv/{map_key}/{sensor}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    reader = csv.DictReader(resp.text.splitlines())
+    availability: Dict[str, Tuple[str, str]] = {}
+    for row in reader:
+        data_id = row.get("data_id")
+        if data_id:
+            availability[data_id] = (row.get("min_date", ""), row.get("max_date", ""))
+    return availability

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,8 +10,8 @@
 ### 查询参数
 - `country`：国家 ISO3 代码，或使用 `west` `south` `east` `north` 指定区域。
 - `start_date`、`end_date`：日期范围，最大 10 天。
-- `source`：数据源，默认 `VIIRS_SNPP_NRT`。
-  可选：`VIIRS_NOAA21_NRT`、`VIIRS_NOAA20_NRT`、`VIIRS_SNPP_NRT`、`VIIRS_NOAA20_SP`、`VIIRS_SNPP_SP`、`MODIS_NRT`、`MODIS_SP`、`LANDSAT_NRT`。
+- `sourcePriority`：逗号分隔的数据源优先级，按顺序选用可用数据集。
+  默认顺序：`VIIRS_NOAA21_NRT,VIIRS_NOAA20_NRT,VIIRS_SNPP_NRT,MODIS_NRT,VIIRS_NOAA21_SP,VIIRS_NOAA20_SP,VIIRS_SNPP_SP,MODIS_SP`。
 
 国家列表来源于 NASA FIRMS `/api/countries/`，后端会缓存 24 小时并用于校验 ISO‑3 代码。
 当未提供 `west/south/east/north` 时，可根据合法的 `country` 自动派生外接盒作为兜底。
@@ -35,3 +35,9 @@
 `https://firms.modaps.eosdis.nasa.gov/api/area/csv/KEY/MODIS_NRT/world/3`
 
 上述 `{START_DATE}` 可选，未提供时默认为当前日期向前追溯 `{DAY_RANGE}` 天。
+
+## 选源逻辑与优先级
+
+调用 `/fires` 前会通过 `/api/data_availability` 检查各数据集的可用日期范围。
+按 `sourcePriority` 列表依次匹配请求的 `[start_date, end_date]`，优先选择 NRT 数据，当所选日期不在 NRT 范围内时自动回退至对应 SP 数据。
+若所有数据源均不覆盖请求区间，将返回空数组，并在响应头 `X-Data-Availability` 中标明原因。


### PR DESCRIPTION
## Summary
- add utility to check dataset availability from NASA FIRMS
- allow `/fires` to select source by availability and priority, with NRT->SP fallback
- document source priority logic and cover fallback cases with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896042149008332acb74cc6692e4983