### PR TITLE
feat: support automatic 10-day range splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A global wildfire data visualization system based on NASA FIRMS API, supporting 
 - Global wildfire data visualization with an interactive map
 - Country or region-based query support
 - Time series data display with a date slider
+- Automatic splitting of date ranges longer than 10 days
 - Detailed wildfire point information
 - Multiple visualization layers:
   - Heatmap (always visible)
@@ -83,7 +84,7 @@ Now you can access the application at http://localhost:3000 in your browser.
 2. Time Selection:
    - Use time slider to select specific date
    - Use forward/backward buttons to navigate adjacent dates
-   - Time span limited to 10 days
+   - Date ranges exceeding 10 days are automatically split into multiple requests
 
 3. Visualization Controls:
    - Heatmap and Clusters are always visible

--- a/backend/test_availability.py
+++ b/backend/test_availability.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient
 from main import app
 
 
@@ -23,12 +24,12 @@ def test_fallback_to_sp(monkeypatch):
 
     called = {}
 
-    def fake_fetch(url):
+    async def fake_fetch(url, client, source):
         called["url"] = url
         return result
 
     monkeypatch.setattr("main.check_data_availability", fake_check)
-    monkeypatch.setattr("main._fetch_firms_data", fake_fetch)
+    monkeypatch.setattr("main._fetch_firms_data_async", fake_fetch)
 
     resp = client.get(
         "/fires",
@@ -57,11 +58,11 @@ def test_no_source_available(monkeypatch):
             "VIIRS_SNPP_SP": ("2023-01-01", "2023-12-31"),
         }
 
-    def fake_fetch(url):
+    async def fake_fetch(url, client, source):
         raise AssertionError("should not be called")
 
     monkeypatch.setattr("main.check_data_availability", fake_check)
-    monkeypatch.setattr("main._fetch_firms_data", fake_fetch)
+    monkeypatch.setattr("main._fetch_firms_data_async", fake_fetch)
 
     resp = client.get(
         "/fires",

--- a/backend/test_urlbuilder.py
+++ b/backend/test_urlbuilder.py
@@ -1,6 +1,11 @@
 from datetime import date
 
-from utils.urlbuilder import build_country_url, build_area_url, compose_urls
+from utils.urlbuilder import (
+    build_country_url,
+    build_area_url,
+    compose_urls,
+    split_date_range,
+)
 
 
 def test_build_country_url_with_and_without_date():
@@ -60,4 +65,13 @@ def test_compose_urls_cross_month_and_year():
     assert urls == [
         "https://firms.modaps.eosdis.nasa.gov/api/country/csv/"
         "K/MODIS_NRT/USA/6/2024-01-28"
+    ]
+
+
+def test_split_date_range():
+    ranges = split_date_range(date(2024, 1, 1), date(2024, 1, 25))
+    assert ranges == [
+        (date(2024, 1, 1), date(2024, 1, 10)),
+        (date(2024, 1, 11), date(2024, 1, 20)),
+        (date(2024, 1, 21), date(2024, 1, 25)),
     ]


### PR DESCRIPTION
## Summary
- add `split_date_range` and integrate with `compose_urls`
- fetch FIRMS segments concurrently with `asyncio.Semaphore` and de-duplicate records
- document automatic date range splitting in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960acb5aa48332a383b33df5744c68