### PR TITLE
feat: add fire stats endpoint

### DIFF
--- a/backend/test_geo.py
+++ b/backend/test_geo.py
@@ -1,15 +1,18 @@
 import pytest
-import pytest
 from services import geo
 
 
-def test_validate_country():
+def test_validate_country(monkeypatch):
+    mock = {"USA": (-179.1, 18.9, 179.7, 71.4)}
+    monkeypatch.setattr(geo, "load_countries", lambda cache_ttl=86400: mock)
     assert geo.validate_country("USA")
     assert not geo.validate_country("ZZZ")
     assert not geo.validate_country("us")
 
 
-def test_country_to_bbox_parses_box():
+def test_country_to_bbox_parses_box(monkeypatch):
+    mock = {"USA": (-179.143503384, 18.9061171430001, 179.780935092, 71.4125023460001)}
+    monkeypatch.setattr(geo, "load_countries", lambda cache_ttl=86400: mock)
     bbox = geo.country_to_bbox("USA")
     assert bbox is not None
     assert bbox == pytest.approx(

--- a/backend/test_stats.py
+++ b/backend/test_stats.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app, compute_stats
+
+
+def test_compute_stats_basic():
+    data = [
+        {"frp": "25", "daynight": "D", "confidence": "85", "satellite": "N"},
+        {"frp": "10", "daynight": "N", "confidence": "50", "satellite": "T"},
+        {"frp": "3", "daynight": "D", "confidence": "l", "satellite": "A"},
+    ]
+    stats = compute_stats(data)
+    assert stats["totalPoints"] == 3
+    assert stats["frpHighCount"] == 1
+    assert stats["frpMidCount"] == 1
+    assert stats["frpLowCount"] == 1
+    assert stats["dayCount"] == 2
+    assert stats["nightCount"] == 1
+    assert stats["highConfidence"] == 1
+    assert stats["mediumConfidence"] == 1
+    assert stats["lowConfidence"] == 1
+    assert stats["viirsCount"] == 1
+    assert stats["terraCount"] == 1
+    assert stats["aquaCount"] == 1
+    assert pytest.approx(stats["avgFrp"], 1e-6) == (25 + 10 + 3) / 3
+    assert stats["maxFrp"] == 25
+    assert stats["sumFrp"] == 38
+
+
+def test_stats_endpoint(monkeypatch):
+    sample = [
+        {"frp": "25", "daynight": "D", "confidence": "85", "satellite": "N"},
+        {"frp": "10", "daynight": "N", "confidence": "50", "satellite": "T"},
+        {"frp": "3", "daynight": "D", "confidence": "l", "satellite": "A"},
+    ]
+
+    async def fake_fetch(urls, selected_source):
+        return sample
+
+    def fake_prepare(*args, **kwargs):
+        return (["u"], "src")
+
+    monkeypatch.setattr("main._fetch_deduped_data", fake_fetch)
+    monkeypatch.setattr("main._prepare_fire_query", fake_prepare)
+
+    client = TestClient(app)
+    resp = client.get("/fires/stats?country=USA&start_date=2024-01-01&end_date=2024-01-01")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totalPoints"] == 3
+    assert body["frpHighCount"] == 1

--- a/docs/API.md
+++ b/docs/API.md
@@ -74,6 +74,42 @@
 }
 ```
 
+## /fires/stats
+统计火点聚合数据，入参与 `/fires` 一致，新增 FRP 档位阈值可配置。
+
+### 查询参数
+- 与 `/fires` 相同的 `country` 或 `west/south/east/north`、`start_date`、`end_date`、`sourcePriority`。
+- `frpHigh`：FRP 高档位阈值，默认 20。
+- `frpMid`：FRP 中档位阈值，默认 5。
+
+### 返回字段
+返回结构与前端面板一致：
+`totalPoints`、`avgFrp`、`maxFrp`、`sumFrp`、`dayCount`、`nightCount`、
+`highConfidence`、`mediumConfidence`、`lowConfidence`、
+`viirsCount`、`terraCount`、`aquaCount`、
+`frpHighCount`、`frpMidCount`、`frpLowCount`。
+
+### 示例
+```json
+{
+  "totalPoints": 3,
+  "avgFrp": 12.67,
+  "maxFrp": 25.0,
+  "sumFrp": 38.0,
+  "dayCount": 2,
+  "nightCount": 1,
+  "highConfidence": 1,
+  "mediumConfidence": 1,
+  "lowConfidence": 1,
+  "viirsCount": 1,
+  "terraCount": 1,
+  "aquaCount": 1,
+  "frpHighCount": 1,
+  "frpMidCount": 1,
+  "frpLowCount": 1
+}
+```
+
 ## URL 拼接规范与样例
 
 ### Country


### PR DESCRIPTION
## Summary
- aggregate FRP, confidence, day/night, and platform stats server-side
- expose new `/fires/stats` API with configurable FRP thresholds
- document stats endpoint and add unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961d8973cc8332a2e5dd188c4cb7f0